### PR TITLE
GP2-2935 DAC_Custom_Controls_03 Tooltips

### DIFF
--- a/dist/components/tooltip/Tooltip.js
+++ b/dist/components/tooltip/Tooltip.js
@@ -25,54 +25,55 @@ function _nonIterableRest() { throw new TypeError("Invalid attempt to destructur
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-var Tooltip = ({
+const Tooltip = ({
   title,
   content,
   position,
   className,
   isVisible,
-  faIcon
+  faIcon,
+  showTitle
 }) => {
   // Init useComponentVisible hook
-  var componentVisible = _useComponentVisible.default;
+  const componentVisible = _useComponentVisible.default;
 
-  var _componentVisible = componentVisible(isVisible),
-      ref = _componentVisible.ref,
-      isComponentVisible = _componentVisible.isComponentVisible,
-      setIsComponentVisible = _componentVisible.setIsComponentVisible;
+  const _componentVisible = componentVisible(isVisible),
+        ref = _componentVisible.ref,
+        isComponentVisible = _componentVisible.isComponentVisible,
+        setIsComponentVisible = _componentVisible.setIsComponentVisible;
 
-  var _useState = (0, _react.useState)(null),
-      _useState2 = _slicedToArray(_useState, 2),
-      tooltipPosition = _useState2[0],
-      setTooltipPosition = _useState2[1];
+  const _useState = (0, _react.useState)(null),
+        _useState2 = _slicedToArray(_useState, 2),
+        tooltipPosition = _useState2[0],
+        setTooltipPosition = _useState2[1];
 
-  var _useState3 = (0, _react.useState)(false),
-      _useState4 = _slicedToArray(_useState3, 2),
-      mount = _useState4[0],
-      setMount = _useState4[1];
+  const _useState3 = (0, _react.useState)(false),
+        _useState4 = _slicedToArray(_useState3, 2),
+        mount = _useState4[0],
+        setMount = _useState4[1];
 
-  var _useState5 = (0, _react.useState)(false),
-      _useState6 = _slicedToArray(_useState5, 2),
-      tooltipOpen = _useState6[0],
-      setTooltipOpen = _useState6[1]; // Find mobile breakpoint width from CSS var
+  const _useState5 = (0, _react.useState)(false),
+        _useState6 = _slicedToArray(_useState5, 2),
+        tooltipOpen = _useState6[0],
+        setTooltipOpen = _useState6[1]; // Find mobile breakpoint width from CSS var
 
 
-  var mobileBreakpoint = Number(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-mobile').replace('px', '')) || 640; // Apply negative margin to the left of the element
+  const mobileBreakpoint = Number(getComputedStyle(document.documentElement).getPropertyValue('--breakpoint-mobile').replace('px', '')) || 640; // Apply negative margin to the left of the element
 
-  var updatePositionOffset = el => {
-    var left = el.current.getClientRects()[0].left;
+  const updatePositionOffset = el => {
+    let left = el.current.getClientRects()[0].left;
     setTooltipPosition({
       marginLeft: window.innerWidth <= mobileBreakpoint ? "calc(-".concat(left, "px + var(--ttpadding))") : null
     });
   };
 
-  var onClickOpen = () => {
+  const onClickOpen = () => {
     setIsComponentVisible(true);
     setTooltipOpen(true);
 
@@ -84,13 +85,13 @@ var Tooltip = ({
     }
   };
 
-  var onClickClose = () => {
+  const onClickClose = () => {
     setIsComponentVisible(false);
     updatePositionOffset(ref);
     setTooltipOpen(false);
   };
 
-  var onKeyClose = key => {
+  const onKeyClose = key => {
     if (key === 'Enter') {
       onClickClose();
     }
@@ -108,7 +109,7 @@ var Tooltip = ({
   }, // eslint-disable-next-line react-hooks/exhaustive-deps
   [isComponentVisible, ref, mount]); // Logic for left or right aligned. Default left.
 
-  var ttPosition = position === 'right' ? 'right' : 'left';
+  const ttPosition = position === 'right' ? 'right' : 'left';
   return /*#__PURE__*/_react.default.createElement("div", {
     className: "tooltip ".concat(className)
   }, /*#__PURE__*/_react.default.createElement("div", {
@@ -117,14 +118,19 @@ var Tooltip = ({
   }, /*#__PURE__*/_react.default.createElement("button", {
     className: "button button--small button--only-icon button--tertiary",
     onClick: onClickOpen,
-    type: "button"
+    type: "button",
+    "aria-haspopup": "dialog"
   }, /*#__PURE__*/_react.default.createElement("i", {
     className: "fas ".concat(faIcon)
-  }))), isComponentVisible && /*#__PURE__*/_react.default.createElement("div", {
+  }), /*#__PURE__*/_react.default.createElement("span", {
+    className: "visually-hidden"
+  }, title))), isComponentVisible && /*#__PURE__*/_react.default.createElement("div", {
     ref: ref,
     className: "tooltip__text tooltip__text--".concat(ttPosition, " bg-white radius radius--small"),
-    style: tooltipPosition
-  }, /*#__PURE__*/_react.default.createElement("span", {
+    style: tooltipPosition,
+    role: "dialog",
+    "aria-labelledby": "tooltip-title"
+  }, /*#__PURE__*/_react.default.createElement("button", {
     className: "tooltip__close",
     title: "Click or press Escape to close Educational moment",
     onClick: onClickClose,
@@ -132,8 +138,11 @@ var Tooltip = ({
     tabIndex: "0"
   }, /*#__PURE__*/_react.default.createElement("i", {
     className: "fas fa-times text-blue-deep-80"
-  })), title && /*#__PURE__*/_react.default.createElement("h2", {
-    className: "tooltip__title h-xs p-t-0 p-b-0"
+  }), /*#__PURE__*/_react.default.createElement("span", {
+    className: "visually-hidden"
+  }, "Click or press Escape to close Educational moment")), /*#__PURE__*/_react.default.createElement("h2", {
+    id: "tooltip-title",
+    className: "tooltip__title h-xs p-t-0 p-b-0 ".concat(showTitle ? '' : 'visually-hidden')
   }, title), /*#__PURE__*/_react.default.createElement("div", {
     className: "tooltip__content text-blue-deep-80"
   }, (0, _reactHtmlParser.default)(content))));
@@ -146,12 +155,14 @@ Tooltip.propTypes = {
   faIcon: _propTypes.default.string,
   isVisible: _propTypes.default.bool,
   position: _propTypes.default.string,
-  title: _propTypes.default.string
+  title: _propTypes.default.string,
+  showTitle: _propTypes.default.bool
 };
 Tooltip.defaultProps = {
   className: '',
   faIcon: 'fa-book',
   isVisible: false,
   position: 'left',
-  title: 'Helpful hint'
+  title: 'Helpful hint',
+  showTitle: true
 };

--- a/dist/hooks/useComponentVisible.js
+++ b/dist/hooks/useComponentVisible.js
@@ -13,27 +13,27 @@ function _nonIterableRest() { throw new TypeError("Invalid attempt to destructur
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 function useComponentVisibleHook(initialIsVisible) {
-  var _useState = (0, _react.useState)(initialIsVisible),
-      _useState2 = _slicedToArray(_useState, 2),
-      isComponentVisible = _useState2[0],
-      setIsComponentVisible = _useState2[1];
+  const _useState = (0, _react.useState)(initialIsVisible),
+        _useState2 = _slicedToArray(_useState, 2),
+        isComponentVisible = _useState2[0],
+        setIsComponentVisible = _useState2[1];
 
-  var ref = (0, _react.useRef)(null);
+  const ref = (0, _react.useRef)(null);
 
-  var handleKeydown = event => {
+  const handleKeydown = event => {
     if (event.key === "Escape") {
       setIsComponentVisible(false);
     }
   };
 
-  var handleClickOutside = event => {
+  const handleClickOutside = event => {
     if (ref.current && !ref.current.contains(event.target)) {
       setIsComponentVisible(false);
     }

--- a/src/components/Tooltip.stories.js
+++ b/src/components/Tooltip.stories.js
@@ -24,8 +24,13 @@ const tooltipData = {
 }
 const tooltipDataRight = {
   ...tooltipData,
-  position: 'right',
   title: 'Custom title',
+  position: 'right',
+}
+
+const tooltipDataTitleHidden = {
+  ...tooltipData,
+  showTitle: false,
 }
 
 const style = {
@@ -51,6 +56,14 @@ export const Tooltip_Right = () => {
   return (
     <div className="bg-blue-deep-60 p-xs" style={styleRight}>
       <Tooltip {...tooltipDataRight} faIcon="fa-info" />
+    </div>
+  )
+}
+
+export const Tooltip_hidden_title = () => {
+  return (
+    <div className="bg-blue-deep-60 p-xs" style={style}>
+      <Tooltip {...tooltipDataTitleHidden} faIcon="fa-info" />
     </div>
   )
 }

--- a/src/components/tooltip/Tooltip.jsx
+++ b/src/components/tooltip/Tooltip.jsx
@@ -10,6 +10,7 @@ export const Tooltip = ({
   className,
   isVisible,
   faIcon,
+  showTitle,
 }) => {
   // Init useComponentVisible hook
   const componentVisible = useComponentVisibleHook
@@ -87,8 +88,10 @@ export const Tooltip = ({
           className="button button--small button--only-icon button--tertiary"
           onClick={onClickOpen}
           type="button"
+          aria-haspopup="dialog"
         >
           <i className={`fas ${faIcon}`} />
+          <span className="visually-hidden">{title}</span>
         </button>
       </div>
       {isComponentVisible && (
@@ -96,8 +99,10 @@ export const Tooltip = ({
           ref={ref}
           className={`tooltip__text tooltip__text--${ttPosition} bg-white radius radius--small`}
           style={tooltipPosition}
+          role="dialog"
+          aria-labelledby="tooltip-title"
         >
-          <span
+          <button
             className="tooltip__close"
             title="Click or press Escape to close Educational moment"
             onClick={onClickClose}
@@ -105,10 +110,9 @@ export const Tooltip = ({
             tabIndex="0"
           >
             <i className="fas fa-times text-blue-deep-80" />
-          </span>
-          {title && (
-            <h2 className="tooltip__title h-xs p-t-0 p-b-0">{title}</h2>
-          )}
+            <span className="visually-hidden">Click or press Escape to close Educational moment</span>
+          </button>
+          {<h2 id="tooltip-title" className={`tooltip__title h-xs p-t-0 p-b-0 ${showTitle ? '' : 'visually-hidden'}`}>{title}</h2>}
           <div className="tooltip__content text-blue-deep-80">
             {ReactHtmlParser(content)}
           </div>
@@ -125,6 +129,7 @@ Tooltip.propTypes = {
   isVisible: PropTypes.bool,
   position: PropTypes.string,
   title: PropTypes.string,
+  showTitle: PropTypes.bool,
 }
 
 Tooltip.defaultProps = {
@@ -133,4 +138,5 @@ Tooltip.defaultProps = {
   isVisible: false,
   position: 'left',
   title: 'Helpful hint',
+  showTitle: true,
 }


### PR DESCRIPTION
This PR adds aria tags and labels to the tooltip component.
For accessibility, we need to label the activation buttons for screen readers. To this end, a title should be supplied, so I've added a prop 'showTitle' (default true) to allow the title to be hidden if required, although it will still be used for aria labelling.

- [ ] Changelog entry added.
- [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
- [ ] CSS have been compiled.
- [ ] Add a printscreen to the PR
- [x] Components have been built for use in e.g. great-cms: `npm run babel`
