### PR TITLE
Fix tar high vulnerability

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,8 @@
     "plugins": [
         ["@babel/plugin-proposal-private-property-in-object", {
             "loose": true
-        }]
+        }],
+        ["@babel/plugin-proposal-class-properties", { "loose": true }],
+        ["@babel/plugin-proposal-private-methods", { "loose": true }]
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18960,9 +18960,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -35520,9 +35520,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-storybook": "build-storybook -s public",
     "dsm-storybook:publish": "dsm-storybook publish",
     "dsm-storybook:preview": "dsm-storybook preview",
-    "babel": "./node_modules/.bin/babel src --ignore '**/*.stories.js' --out-dir ./dist"
+    "babel": "./node_modules/.bin/babel src --ignore '**/*.stories.js','./src/index.js' --out-dir ./dist"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Resolves `tar` vulnerability (https://github.com/uktrade/great-styles/security/dependabot/package-lock.json/tar/open).

To do (delete all that do not apply):

- [ ] Changelog entry added.
- [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
- [x] CSS have been compiled.
- [ ] Add a printscreen to the PR
- [x] Components have been built for use in e.g. great-cms: `npm run babel`
