### PR TITLE
GP2-3810 Tooltips and GP2-2948 Contrast

### DIFF
--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -37,7 +37,7 @@
 }
 
 .tooltip__text--right {
-  transform: translateX(calc(-100% + 40px));
+  transform: translateX(calc(-100% + 70px));
 
   @include breakpoint(sm) {
     left: auto;

--- a/src/scss/elements/forms/_general.scss
+++ b/src/scss/elements/forms/_general.scss
@@ -96,7 +96,7 @@ select.form-control {
   color: $blue-deep-60;
   width: 100%;
   padding: 0;
-  border: 2px solid $blue-deep-20;
+  border: 2px solid $blue-deep-50;
   border-radius: 10px;
 }
 
@@ -403,7 +403,7 @@ select::-ms-expand {
 }
 
 .prepend {
-  border: 2px solid $colour-blue-deep-20;
+  border: 2px solid $colour-blue-deep-50;
   border-radius: 10px 0 0 10px;
   border-right-style: none;
   padding: 8px;

--- a/src/scss/elements/forms/_select.scss
+++ b/src/scss/elements/forms/_select.scss
@@ -28,7 +28,7 @@
   }
 
   &__placeholder {
-    border: 2px solid $colour-blue-deep-20;
+    border: 2px solid $colour-blue-deep-50;
     min-height: 50px;
     padding: 10px 30px 10px 15px;
     position: static;
@@ -82,7 +82,7 @@
     z-index: 2;
     overflow: hidden;
 
-    border: 2px solid $colour-blue-deep-20;
+    border: 2px solid $colour-blue-deep-50;
     border-top: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;

--- a/src/scss/elements/forms/_select.scss
+++ b/src/scss/elements/forms/_select.scss
@@ -15,7 +15,7 @@
     i {
       width: 15px;
       transition: color 150ms, transform 250ms;
-      color: $colour-blue-deep-20;
+      color: $colour-blue-deep-50;
     }
 
     &:hover i {


### PR DESCRIPTION
Before:
<img width="606" alt="Screenshot 2021-11-22 at 20 24 29" src="https://user-images.githubusercontent.com/24960282/142940481-5f2bd8a2-a094-45c2-baa5-d9469c391777.png">
![image](https://user-images.githubusercontent.com/24960282/142940492-9d095518-7e20-4e85-b213-8ba17f80ee5b.png)
After:
<img width="453" alt="Screenshot 2021-11-22 at 21 49 11" src="https://user-images.githubusercontent.com/24960282/142940512-f9bfe11e-5e29-4f72-ab18-6c8f18ad46b0.png">
![image](https://user-images.githubusercontent.com/24960282/142940783-89011bd2-254a-4f48-b851-ef0dfe23d9f8.png)
<img width="488" alt="Screenshot 2021-11-25 at 16 18 48" src="https://user-images.githubusercontent.com/24960282/143475162-10dc0c05-9e8a-457f-b9d9-cdd147b2f75e.png">



https://uktrade.atlassian.net/browse/GP2-2948
https://uktrade.atlassian.net/browse/GP2-3810

- [x] Changelog entry added.
- [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
- [ ] CSS have been compiled.
- [ ] Add a printscreen to the PR
- [ ] Components have been built for use in e.g. great-cms: `npm run babel`
